### PR TITLE
Adding in setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,21 @@
+[metadata]
+name = datamined 
+author = Bharath Ramsundar
+summary = A Protocol for Owning and Sharing Data Securely 
+description-file = README.md
+home-page = https://github.com/datamined/datamined
+license = MIT
+classifier =
+    Development Status :: 4 - Beta
+    Environment :: Console
+    Intended Audience :: Developers
+    Intended Audience :: Information Technology
+    License :: OSI Approved :: MIT
+    Operating System :: OS Independent
+    Programming Language :: Python :: 2.7
+keywords =
+    setup
+    distutils
+[files]
+packages =
+    datamined


### PR DESCRIPTION
Forgot to add in `setup.cfg`. Now `python setup.py develop` works and `import datamined` runs.