### PR TITLE
First changes for solidity integration

### DIFF
--- a/datacoin/contracts/DataCoin.sol
+++ b/datacoin/contracts/DataCoin.sol
@@ -1,5 +1,5 @@
 /**
- * The Edgeless token contract complies with the ERC20 standard (see
+ * The DataCoin token contract complies with the ERC20 standard (see
  * https://github.com/ethereum/EIPs/issues/20).  Additionally tokens
  * can be locked for a defined time interval by token holders.  The
  * owner's share of tokens is locked for the first 360 days and all
@@ -19,15 +19,16 @@ contract tokenRecipient {
 import "./TestableNow.sol";
 import "./SafeMath.sol";
 
-contract EdgelessToken is SafeMath, TestableNow {
+contract DataCoin is SafeMath, TestableNow {
     /* Public variables of the token */
     string public standard = 'ERC20';
-    string public name = 'Edgeless';
+    string public name = 'DataCoin';
     string public symbol = 'EDG';
     uint8 public decimals = 0;
     uint256 public totalSupply;
     address public owner;
     /* from this time on tokens may be transfered (after ICO)*/
+    // TODO(rbharath): What should startTime be changed to?
     uint256 public startTime = 1490112000;
     /* tells if tokens have been burned already */
     bool public burned;
@@ -49,7 +50,7 @@ contract EdgelessToken is SafeMath, TestableNow {
 
     /* Initializes contract with initial supply tokens to the creator
     * of the contract */
-    function EdgelessToken(address _owner) {
+    function DataCoin(address _owner) {
         // Owner is the crowdsale contract
         owner = _owner;
         // Give the owner all initial tokens

--- a/datacoin/contracts/DataMined.sol
+++ b/datacoin/contracts/DataMined.sol
@@ -1,5 +1,5 @@
 /**
-*	Crowdsale for Edgeless Tokens.
+*	Crowdsale for Datacoin Tokens.
 *	Raised Ether will be stored safely at a multisignature wallet and returned to the ICO in case the funding goal is not reached,
 *   allowing the investors to withdraw their funds.
 *	Author: Julia Altenried

--- a/datacoin/tests/test_erc20.py
+++ b/datacoin/tests/test_erc20.py
@@ -6,7 +6,7 @@ from web3.contract import Contract
 
 
 def test_erc20_interface(erc20_token, token_owner, empty_address):
-  """Edgeless token satisfies ERC-20 interface."""
+  """DataCoin satisfies ERC-20 interface."""
 
   # https://github.com/OpenZeppelin/zeppelin-solidity/blob/master/contracts/token/ERC20.sol
 
@@ -69,7 +69,7 @@ def test_erc20_transfer_with_allowance(erc20_token, token_owner, empty_address,
   assert token.call().allowance(token_owner, allowed_party) == amount
 
   events = token.pastEvents("Approval").get()
-  # Edgeless gets 2 events, because one is needed to construct token
+  # DataCoin gets 2 events, because one is needed to construct token
   assert len(events) > 0
   e = events[-1]
   # TODO(rbharath): Is this call to lower() valid? Original test

--- a/datamined/coins/__init__.py
+++ b/datamined/coins/__init__.py
@@ -7,3 +7,4 @@ from __future__ import unicode_literals
 
 from datamined.coins.wallets import Wallet 
 from datamined.coins.wallets import ExampleWallet 
+from datamined.coins.wallets import LocalGethWallet 

--- a/datamined/compute/nodes.py
+++ b/datamined/compute/nodes.py
@@ -84,7 +84,7 @@ class GenomicCountInsecureFileNode(Node):
     for base_pair in ["A", "C", "G", "T"]:
       results[base_pair] = data.count(base_pair)
       # TODO(rbharath): This money needs to come from somewhere!!
-      self.wallet.increment(self.compute_reward)
+      self.wallet.deposit(self.compute_reward)
     return results
 
   def get_wallet(self):

--- a/datamined/data/clients.py
+++ b/datamined/data/clients.py
@@ -103,7 +103,7 @@ class InsecureFileClient(Client):
       if validator.is_valid(data):
         data_file.write(data)
         # Increment wallet token count
-        self.wallet.increment(self.data_reward)
+        self.wallet.deposit(self.data_reward)
       else:
         raise ValueError("This data is not valid")
       return data_file.name

--- a/examples/compute_workflow.py
+++ b/examples/compute_workflow.py
@@ -1,7 +1,7 @@
-# Provides a simple example of how to perform computation with the datamined
-# API. Data is stored using dm.data.Client objects. Them dm.compute.Node
-# instances perform a basic computation upon the data from the corresponding
-# nodes.
+# Provides a simple example of how to perform computation with the
+# datamined API. Data is stored using dm.data.Client objects. Them
+# dm.compute.Node instances perform a basic computation upon the data
+# from the corresponding nodes.
 
 import datamined as dm
 
@@ -15,10 +15,10 @@ assert validator.is_valid(data)
 
 # Create an introductory client wallet 
 client_wallet = dm.coins.ExampleWallet()
-assert client_wallet.token_count() == 0
+assert client_wallet.get_balance() == 0
 
 client = dm.data.InsecureFileClient(private_key, client_wallet)
-assert client.get_wallet().token_count() == 0
+assert client.get_wallet().get_balance() == 0
 ledger = client.store(data, validator)
 
 # Assumes that dm.data.Client objects have the ability to generate
@@ -32,7 +32,7 @@ ledger_key = client.get_ledger_key(ledger)
 
 # Create an introductory node wallet 
 node_wallet = dm.coins.ExampleWallet()
-assert node_wallet.token_count() == 0
+assert node_wallet.get_balance() == 0
 
 node = dm.compute.GenomicCountInsecureFileNode(node_wallet)
 # It's still an open question how a Node can perform arbitrary computations. In
@@ -40,6 +40,6 @@ node = dm.compute.GenomicCountInsecureFileNode(node_wallet)
 # limited set of computations linked to by keywords.
 results = node.compute(ledger, ledger_key, "count-basepairs")
 # The node should have been paid for this computation
-assert node.get_wallet().token_count() > 0
+assert node.get_wallet().get_balance() > 0
 
 assert results == {"A": 6, "T": 6, "G": 2, "C": 1}

--- a/examples/wallets.py
+++ b/examples/wallets.py
@@ -1,0 +1,26 @@
+import datamined as dm
+
+data = "ATTAGGACATTTATA"
+private_key = "*&^#*HWEF(#@*R#(@JF"
+
+# Create an introductory client wallet 
+client_wallet = dm.coins.LocalGethWallet()
+
+# TODO(rbharath): The wallet currently retains memory on the chain.
+# This isn't desirable. Is there a good way to make sure a new wallet
+# is made each time? The following code executes cleanup.
+current_balance = client_wallet.get_balance()
+client_wallet.withdraw(current_balance)
+
+print("client_wallet.get_balance()", client_wallet.get_balance())
+assert client_wallet.get_balance() == 0
+
+# Deposit into wallet
+client_wallet.deposit(10)
+print("client_wallet.get_balance()", client_wallet.get_balance())
+assert client_wallet.get_balance() == 10
+
+# Withdraw from wallet
+client_wallet.withdraw(7)
+print("client_wallet.get_balance()", client_wallet.get_balance())
+assert client_wallet.get_balance() == 3


### PR DESCRIPTION
This PR makes the first changes to integrate solidity contracts into the `datamined` package. In particular, i introduces a class `LocalGethWallet` that connects with the deployed instance of `datacoints/contracts/Wallet.sol` which it uses to function as a wallet. Note that this PR also changes the abstract `Wallet` class to bring its method names to match `Wallet.sol`.

One major bug here: The current implementation has memory; it's not yet clear how to make multiple independent wallets based off the deployed `Wallet.sol` contract. Noted here and should be fixed in a future PR.