### PR TITLE
Adding first contract tests

### DIFF
--- a/datamined/coins/tests/test_datacoin.py
+++ b/datamined/coins/tests/test_datacoin.py
@@ -1,0 +1,107 @@
+"""
+Tests for wallet creation 
+"""
+from __future__ import print_function
+from __future__ import division
+from __future__ import unicode_literals
+
+import unittest
+import web3
+import datamined as dm
+from populus import Project
+from datamined.coins.wallets import DATACOIN_PATH
+
+
+class TestDataCoin(unittest.TestCase):
+  """
+  Test API for DataCoins. 
+  """
+
+  def test_token_basic(self):
+    """Does basic tests on crowdsale construction"""
+    project_dir = DATACOIN_PATH
+    project = Project(project_dir)
+    chain_name = "tester"
+
+    with project.get_chain(chain_name) as chain:
+      # TODO(rbharath): These default accounts are set by populus
+      # somewhere. Figure out how to configure this directly.
+      # setup
+      accounts = chain.web3.eth.accounts
+      beneficiary = accounts[3]
+      multisig = accounts[4]
+      # crowdsale
+      args = [beneficiary, multisig, 0]
+      crowdsale, _ = chain.provider.get_or_deploy_contract(
+          'Crowdsale', deploy_args=args)
+      # Token contract address is not yet set.
+      assert crowdsale.call().tokenReward(
+      ) == '0x0000000000000000000000000000000000000000'
+
+  def test_token_initialized(self):
+    """Crowdsale is properly initialized with given parameters."""
+    project_dir = DATACOIN_PATH
+    project = Project(project_dir)
+    chain_name = "tester"
+
+    with project.get_chain(chain_name) as chain:
+      # setup
+      accounts = chain.web3.eth.accounts
+      beneficiary = accounts[3]
+      multisig = accounts[4]
+      # crowdsale
+      args = [beneficiary, multisig, 0]
+      crowdsale, _ = chain.provider.get_or_deploy_contract(
+          'Crowdsale', deploy_args=args)
+
+      # token
+      token, _ = chain.provider.get_or_deploy_contract(
+          'DataCoin', deploy_args=[beneficiary])
+      assert crowdsale.call().tokenReward(
+      ) == '0x0000000000000000000000000000000000000000'
+      # Assert that the crowdsale address is now set
+      crowdsale.transact({"from": beneficiary}).setToken(token.address)
+      assert crowdsale.call().tokenReward(
+      ) != '0x0000000000000000000000000000000000000000'
+
+      assert token.call().balanceOf(beneficiary) == 500000000
+      assert token.call().totalSupply() == 500000000
+      assert token.call().owner().lower() == beneficiary
+      # TODO(rbharath): Figure out why these aren't running.
+      #assert token.call().allowance(beneficiary, crowdsale.address) == 440000000
+      #assert token.call().owner().lower() == crowdsale.call().beneficiary().lower()
+
+    # TODO(rbharath): This is adapted directly from the example code. Doesn't make sense for DataMined, so remove in future PR.
+    #def test_get_price_tiers(crowdsale, token, customer, web3):
+  def test_get_price_tiers(self):
+    """Price tiers match given dates."""
+    project_dir = DATACOIN_PATH
+    project = Project(project_dir)
+    chain_name = "tester"
+
+    with project.get_chain(chain_name) as chain:
+      # setup
+      accounts = chain.web3.eth.accounts
+      customer = accounts[1]
+      beneficiary = accounts[3]
+      multisig = accounts[4]
+      # crowdsale
+      crowdsale, _ = chain.provider.get_or_deploy_contract(
+          'Crowdsale', deploy_args=[beneficiary, multisig, 0])
+      # token
+      token, _ = chain.provider.get_or_deploy_contract(
+          'DataCoin', deploy_args=[beneficiary])
+      crowdsale.transact({"from": beneficiary}).setToken(token.address)
+
+      deadlines = [1488297600, 1488902400, 1489507200, 1490112000]
+      prices = [
+          833333333333333, 909090909090909, 952380952380952, 1000000000000000
+      ]
+
+      for idx, deadline in enumerate(deadlines):
+        crowdsale.transact().setCurrent(deadline - 1)
+        assert crowdsale.call().getPrice() == prices[idx]
+
+      # Post last deadline prcie
+      crowdsale.transact().setCurrent(deadlines[-1] + 1)
+      assert crowdsale.call().getPrice() == 1000000000000000

--- a/datamined/coins/wallets.py
+++ b/datamined/coins/wallets.py
@@ -104,7 +104,12 @@ class ExampleWallet(object):
 
 
 class LocalGethWallet(Wallet):
-  """A wallet that deals with DataCoins on a local Geth node."""
+  """A wallet that deals with DataCoins on a local Geth node.
+  
+  TODO(rbharath): I suspect that this code could work on test nodes
+  and perhaps the main ethereum network as well. Need to do more
+  tests to verify this though. 
+  """
 
   def __init__(self, project_dir=None, chain_name="tester", wait=False):
     """Initializes wallet.
@@ -115,10 +120,15 @@ class LocalGethWallet(Wallet):
 
     Parameters
     ----------
-    project: populus.Project
-     Project that chain is running under.
+    project_dir: str
+      The directory in which the populus project contain contracts is
+      stored.
+    chain_name: str
+      Name of the blockchain to which we connect.
+    wait: bool
+      Does this wallet wait for transactions to clear before
+      returning.
     """
-    # TODO(rbharath): Replace this with a command-line config.
     if project_dir is None:
       project_dir = DATACOIN_PATH
     self.project_dir = project_dir


### PR DESCRIPTION
Adding some tests for the `DataCoin` and `Crowdsale` contracts. These tests are directly adapted from the https://github.com/miohtama/Edgeless-Smart-Contracts tests for these contracts, but have been moved to use `unittest` instead of `pytest`. (The nested dependency structure of `pytest` makes it hard to control precisely what's happening in a unit test. `unittest` does this much better, admittedly at the cost of greater verbosity).

Many of these unit tests test specific conditions of the `Crowdsale` contract which don't make sense for DataMined, but it's useful to have the tests harnessed in so changes to the contracts can be made incrementally with Travis catching regressions.